### PR TITLE
feat: No release for chore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ The first line will be taken from the `title` of the pull request. The following
 
     This is used for bugfixes. A new patch version will be released.
 
-- `chore`
-
-    This is used for other work that should trigger a new release and create an entry in the changelog. A new patch version will be released.
-
 For the rest of the commit message, the description of the pull request (i.e. first comment) is searched for the `## Changelog` heading. Hence, the description for the sample might look like:
 
 ```
@@ -50,7 +46,7 @@ BREAKING CHANGE: You must update the configuration.
 This will be ignored, too.
 ```
 
-If a line in section `Changelog` starts with `BREAKING CHANGE:`, a `major` release will be triggered. 
+If a line in section `Changelog` starts with `BREAKING CHANGE:`, a `major` release will be triggered.
 
 ### Merging
 

--- a/lib/getReleaseType.js
+++ b/lib/getReleaseType.js
@@ -8,16 +8,12 @@ const getReleaseType = async function (message = '') {
   debug('Start')
   debug(`message: '${message}'`)
 
-  if (!message.match(/^(feat|fix|chore)(\(.*?\))?: /)) {
-    debug('Message must start with \'feat: \', \'fix: \' or \'chore: \'. Release type reset to null.')
+  if (!message.match(/^(feat|fix)(\(.*?\))?: /)) {
+    debug('Message must start with \'feat: \' or \'fix: \'. Release type reset to null.')
     return null
   }
 
-  const type = await commitAnalyzer({
-    releaseRules: [
-      { type: 'chore', release: 'patch' }
-    ]
-  }, {
+  const type = await commitAnalyzer({}, {
     commits: [{ message }],
     logger: console
   })

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -19,7 +19,6 @@ const merge = async function ({ context }) {
     '',
     '- `feat:` for new features (minor release)',
     '- `fix:` for bugfixes (patch release)',
-    '- `chore:` for other work that should be added to the changelog (patch release)',
     '',
     'To create a major release add the following section to the description, too:',
     '```',


### PR DESCRIPTION
## Changelog

Breaking Change: The prefix `chore` will no longer trigger a release.