### PR TITLE
Use 'BREAKING CHANGES' as keyword, fix regex.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ feat: Introducing a cool feature.
 
 The new feature is awesome!
 
-BREAKING CHANGE: You must update the configuration.
+BREAKING CHANGES: You must update the configuration.
 ```
 
 The first line will be taken from the `title` of the pull request. The following prefixes are recognized:
@@ -39,14 +39,14 @@ This text will not be included in the commit message
 
 The new feature is awesome!
 
-BREAKING CHANGE: You must update the configuration.
+BREAKING CHANGES: You must update the configuration.
 
 ## Another section
 
 This will be ignored, too.
 ```
 
-If a line in section `Changelog` starts with `BREAKING CHANGE:`, a `major` release will be triggered.
+If a line in section `Changelog` starts with `BREAKING CHANGES:`, a `major` release will be triggered.
 
 ### Merging
 

--- a/lib/extractConventionalCommitMessage.js
+++ b/lib/extractConventionalCommitMessage.js
@@ -5,13 +5,8 @@ const debug = require('debug')('app:extractConventionalCommitMessage')
 const extractConventionalCommitMessage = function (body = '') {
   debug('Start')
 
-  const markers = {
-    start: '## Changelog',
-    end: '#'
-  }
-
-  let message = new RegExp(`${markers.start}([^]*?)(${markers.end}|$)`).exec(body)
-  message = message ? message[1] : ''
+  let message = /(^#+ |\n#+ )Changelog([^]*?)(^#+ |\n#+ |$)/.exec(body)
+  message = message ? message[2] : ''
 
   // Remove all leading and trailing whitespaces
   message = new RegExp(`^\\s*([^]*?)\\s*$`).exec(message)

--- a/lib/getReleaseType.js
+++ b/lib/getReleaseType.js
@@ -13,7 +13,12 @@ const getReleaseType = async function (message = '') {
     return null
   }
 
-  const type = await commitAnalyzer({}, {
+  const type = await commitAnalyzer({
+    preset: 'angular',
+    parserOpts: {
+      noteKeywords: ['BREAKING CHANGES']
+    }
+  }, {
     commits: [{ message }],
     logger: console
   })

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -22,9 +22,9 @@ const merge = async function ({ context }) {
     '',
     'To create a major release add the following section to the description, too:',
     '```',
-    '## Changelog',
+    '### Changelog',
     '',
-    'BREAKING CHANGE: <Your description of the breaking change>',
+    'BREAKING CHANGES: <Your description of the breaking change>',
     '```'
   ]
   const manualMergeInfo = [

--- a/test/unit/lib/extractConventionalMessage.test.js
+++ b/test/unit/lib/extractConventionalMessage.test.js
@@ -58,6 +58,28 @@ describe('extractConventionalCommitMessage', () => {
     expect(extractConventionalCommitMessage(body)).toBe(expected)
   })
 
+  it('ignores # in the middle of the changelog section.', async () => {
+    const body = [
+      '## First Section',
+      'line 1',
+      'line 2',
+      '## Changelog',
+      'message #1',
+      'message #2',
+      'message ### 123',
+      '## Other Section',
+      'line 1',
+      'line 2'
+    ].join('\n')
+    const expected = [
+      'message #1',
+      'message #2',
+      'message ### 123'
+    ].join('\n')
+
+    expect(extractConventionalCommitMessage(body)).toBe(expected)
+  })
+
   it('trims the message.', async () => {
     const body = [
       '## First Section',

--- a/test/unit/lib/getReleaseType.test.js
+++ b/test/unit/lib/getReleaseType.test.js
@@ -9,7 +9,7 @@ describe('getReleaseType', () => {
     const message = [
       'feat: message 1',
       '',
-      'BREAKING CHANGE: message 2'
+      'BREAKING CHANGES: message 2'
     ].join('\n')
 
     expect(await getReleaseType(message)).toEqual('major')


### PR DESCRIPTION
- Set `BREAKING CHANGES` explicitly as the only keyword vor major releases.
- Ignore `#` in the middle of the Changelog section.
- Title of the Changelog section may be indented as the user wishes.